### PR TITLE
add Petabridge.Cmd for cluster management; use CoordinatedShutdown for graceful exit

### DIFF
--- a/SeedNode/SeedNode.cs
+++ b/SeedNode/SeedNode.cs
@@ -32,7 +32,7 @@ namespace SeedNode
             // allow process to exit when Control + C is invoked
             Console.CancelKeyPress += (sender, e) =>
             {
-                CoordinatedShutdown.Get(cluster).Run(CoordinatedShutdown.ClrExitReason.Instance);
+                CoordinatedShutdown.Get(cluster).Run(CoordinatedShutdown.ClrExitReason.Instance).Wait();
             };
 
             cluster.WhenTerminated.Wait();

--- a/SeedNode/SeedNode.cs
+++ b/SeedNode/SeedNode.cs
@@ -1,7 +1,11 @@
-﻿using Akka.Actor;
+﻿using System;
+using Akka.Actor;
 using Akka.Configuration;
 using Serilog;
 using System.IO;
+using Petabridge.Cmd;
+using Petabridge.Cmd.Cluster;
+using Petabridge.Cmd.Host;
 
 namespace SeedNode
 {
@@ -19,6 +23,17 @@ namespace SeedNode
             var config = ConfigurationFactory.ParseString(hocon);
 
             var cluster = ActorSystem.Create("MyCluster", config);
+
+            // use PBM to manage cluster membership
+            var pbm = PetabridgeCmd.Get(cluster);
+            pbm.RegisterCommandPalette(ClusterCommands.Instance); // activate clustering commands
+            pbm.Start(); // start Petabridge.Cmd host on 9110 (configured in HOCON)
+
+            // allow process to exit when Control + C is invoked
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                CoordinatedShutdown.Get(cluster).Run(CoordinatedShutdown.ClrExitReason.Instance);
+            };
 
             cluster.WhenTerminated.Wait();
         }

--- a/SeedNode/SeedNode.csproj
+++ b/SeedNode/SeedNode.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="akka.cluster" Version="1.3.10" />
     <PackageReference Include="Akka.Cluster.SplitBrainResolver " Version="0.0.4" />
     <PackageReference Include="akka.logger.serilog" Version="1.3.9" />
+    <PackageReference Include="Petabridge.Cmd.Cluster" Version="0.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 

--- a/SeedNode/seedNode.hocon
+++ b/SeedNode/seedNode.hocon
@@ -23,6 +23,7 @@ akka {
         seed-nodes = [
             "akka.tcp://MyCluster@localhost:4053"]
         roles = ["beacon"]
+		downing-provider-class = "Akka.Cluster.SplitBrainResolver, Akka.Cluster"
         split-brain-resolver {
             active-strategy = keep-referee
             stable-after = 5s

--- a/SeedNode/seedNode.hocon
+++ b/SeedNode/seedNode.hocon
@@ -1,3 +1,9 @@
+# based on values from https://cmd.petabridge.com/articles/install/host-configuration.html
+petabridge.cmd{
+	# default port number used to listen for incoming petabridge.cmd client connections
+	port = 9110
+}
+
 akka {
     loglevel=INFO,
     loggers=["Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog"]

--- a/SeedNode/seedNode.hocon
+++ b/SeedNode/seedNode.hocon
@@ -32,5 +32,6 @@ akka {
                 down-all-if-less-than-nodes = 1
             }
         }
+		role.worker.min-nr-of-members = 1
     }
 }

--- a/WatchDog/Program.cs
+++ b/WatchDog/Program.cs
@@ -5,12 +5,13 @@ using Serilog;
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace WatchDog
 {
     internal static class MainClass
     {
-        public static void Main()
+        public static async Task Main()
         {
             Log.Logger = new LoggerConfiguration()
                             .WriteTo.Console()
@@ -28,15 +29,25 @@ namespace WatchDog
 
             var random = new Random();
 
-            while (true)
-            {
-                Thread.Sleep(2000);
-                var number1 = random.Next(10);
-                var number2 = random.Next(10);
-                Log.Logger.Information("Adding number {Number1} and number {Number2}", number1, number2);
-                var job = new CalculationJob(number1, number2, "ADD");
-                worker.Tell(job);
-            }
+            var recurringTask = cluster.Scheduler.Advanced.ScheduleRepeatedlyCancelable(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2),
+                () =>
+                {
+                    var number1 = random.Next(10);
+                    var number2 = random.Next(10);
+                    Log.Logger.Information("Adding number {Number1} and number {Number2}", number1, number2);
+                    var job = new CalculationJob(number1, number2, "ADD");
+                    worker.Tell(job);
+                });
+
+            // allow process to exit when Control + C is invoked
+            Console.CancelKeyPress += (sender, e) =>
+                {
+                    CoordinatedShutdown.Get(cluster).Run(CoordinatedShutdown.ClrExitReason.Instance);
+                };
+
+            // don't terminate process unless this node is downed or Control + C is invoked.
+            await cluster.WhenTerminated;
         }
+
     }
 }

--- a/WatchDog/Program.cs
+++ b/WatchDog/Program.cs
@@ -42,7 +42,7 @@ namespace WatchDog
             // allow process to exit when Control + C is invoked
             Console.CancelKeyPress += (sender, e) =>
                 {
-                    CoordinatedShutdown.Get(cluster).Run(CoordinatedShutdown.ClrExitReason.Instance);
+                    CoordinatedShutdown.Get(cluster).Run(CoordinatedShutdown.ClrExitReason.Instance).Wait();
                 };
 
             // don't terminate process unless this node is downed or Control + C is invoked.

--- a/WatchDog/WatchDog.csproj
+++ b/WatchDog/WatchDog.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>osx-x64;win-x64</RuntimeIdentifiers>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WatchDog/watchDog.hocon
+++ b/WatchDog/watchDog.hocon
@@ -27,6 +27,7 @@ akka {
         seed-nodes = [
             "akka.tcp://MyCluster@localhost:4053"]
         roles = ["watchdog"]
+		downing-provider-class = "Akka.Cluster.SplitBrainResolver, Akka.Cluster"
         split-brain-resolver {
             active-strategy = keep-referee
             stable-after = 5s

--- a/WatchDog/watchDog.hocon
+++ b/WatchDog/watchDog.hocon
@@ -36,6 +36,7 @@ akka {
                 down-all-if-less-than-nodes = 1
             }
         }
+		role.worker.min-nr-of-members = 1
 
     }
 }

--- a/Worker/Worker.cs
+++ b/Worker/Worker.cs
@@ -1,4 +1,5 @@
-﻿using Akka.Actor;
+﻿using System;
+using Akka.Actor;
 using Akka.Cluster;
 using Akka.Configuration;
 using Serilog;
@@ -21,6 +22,12 @@ namespace Worker
             Log.Logger.Information("Actor system created");
 
             Log.Logger.Information("Actor system joined cluster");
+
+            // allow process to exit when Control + C is invoked
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                CoordinatedShutdown.Get(actorsytem).Run(CoordinatedShutdown.ClrExitReason.Instance);
+            };
 
             actorsytem.WhenTerminated.Wait();
             Log.Logger.Information("Actor system terminated");

--- a/Worker/Worker.cs
+++ b/Worker/Worker.cs
@@ -26,7 +26,7 @@ namespace Worker
             // allow process to exit when Control + C is invoked
             Console.CancelKeyPress += (sender, e) =>
             {
-                CoordinatedShutdown.Get(actorsytem).Run(CoordinatedShutdown.ClrExitReason.Instance);
+                CoordinatedShutdown.Get(actorsytem).Run(CoordinatedShutdown.ClrExitReason.Instance).Wait();
             };
 
             actorsytem.WhenTerminated.Wait();

--- a/Worker/worker.hocon
+++ b/Worker/worker.hocon
@@ -27,5 +27,6 @@ akka {
                 down-all-if-less-than-nodes = 1
             }
         }
+		role.worker.min-nr-of-members = 1
     }
 }

--- a/Worker/worker.hocon
+++ b/Worker/worker.hocon
@@ -18,7 +18,7 @@ akka {
             "akka.tcp://MyCluster@localhost:4053"]
         roles = ["worker"]
 
-        downing-provider-class = "Akka.Cluster.SplitBrainResolver.SplitBrainResolverDowningProvider, Akka.Cluster.SplitBrainResolver"
+        downing-provider-class = "Akka.Cluster.SplitBrainResolver, Akka.Cluster"
         split-brain-resolver {
             active-strategy = keep-referee
             stable-after = 5s


### PR DESCRIPTION
Meant to address the main concern here.

I installed [Petabridge.Cmd](https://cmd.petabridge.com/) into the `SeedNode` project in order to have some manual control over the cluster. The `Petabridge.Cmd.Host` listens on port 9110 by default and you need to install the [`pbm` client](https://www.nuget.org/packages/pbm/) in order to communicate with it.

But once you have `pbm` up and running, here's what the output looks like when we kill off one node, ungracefully (abort), and that node becomes unreachable:

![image](https://user-images.githubusercontent.com/326939/49255509-d8840a00-f3f1-11e8-9187-08aca763823e.png)

You can see the old node is unreachable and the new node we launched via `dotnet run` inside the Worker project is stuck at joining. I can fix this via the [`cluster down-unreachable` command](https://cmd.petabridge.com/articles/commands/cluster-commands.html#cluster-down-unreachable) in `pbm`:

![image](https://user-images.githubusercontent.com/326939/49255593-200a9600-f3f2-11e8-87b4-8c66fadd04a4.png)

And the new state of the cluster now looks like:

![image](https://user-images.githubusercontent.com/326939/49255612-2bf65800-f3f2-11e8-94b3-edad73010ce1.png)

And we can see that the new worker is happy now:

![image](https://user-images.githubusercontent.com/326939/49255645-43354580-f3f2-11e8-8e5d-0d7ea2222dc2.png)


## Technically, the split-brain resolver should be able to handle this automatically.

So I think it might be configured incorrectly - I'm going to check.